### PR TITLE
Sj/implement transitions

### DIFF
--- a/src/client/Root.tsx
+++ b/src/client/Root.tsx
@@ -16,18 +16,21 @@ import Login from './components/Login';
 import UserPostsWrapper from './components/UserPostsWrapper';
 import Dashboard from './components/Dashboard';
 
+
+const routes = [
+  { path: '/', name: 'Home', element: <HomeWrapper />, nodeRef: createRef() as RefObject<HTMLElement>},
+  { path: '/explore', name: 'Explore', element: <ExploreChaanWrapper />, nodeRef: createRef() as RefObject<HTMLElement>},
+  { path: '/about', name: 'About', element: <About />, nodeRef: createRef() as RefObject<HTMLElement>},
+  { path: '/login', name: 'Login', element: <Login />, nodeRef: createRef() as RefObject<HTMLElement>},
+  { path: '/user', name: 'Dashboard', element: <Dashboard />, nodeRef: createRef() as RefObject<HTMLElement>},
+  { path: '/posts/:user_id', name: 'UserPosts', element: <UserPostsWrapper />, nodeRef: createRef() as RefObject<HTMLElement>},
+];
+
 const Root = () => {
 
 // per info, useRef(null) is the functional component way of creating refs, createRef() was
 // the older class based way of creating refs???
-  const routes = [
-    { path: '/', name: 'Home', element: <HomeWrapper />, nodeRef: createRef() as RefObject<HTMLElement>},
-    { path: '/explore', name: 'Explore', element: <ExploreChaanWrapper />, nodeRef: createRef() as RefObject<HTMLElement>},
-    { path: '/about', name: 'About', element: <About />, nodeRef: createRef() as RefObject<HTMLElement>},
-    { path: '/login', name: 'Login', element: <Login />, nodeRef: createRef() as RefObject<HTMLElement>},
-    { path: '/user', name: 'Dashboard', element: <Dashboard />, nodeRef: createRef() as RefObject<HTMLElement>},
-    { path: '/posts/:user_id', name: 'UserPosts', element: <UserPostsWrapper />, nodeRef: createRef() as RefObject<HTMLElement>},
-  ];
+
 
   const location = useLocation();
 
@@ -43,11 +46,12 @@ const Root = () => {
               <CSSTransition
                 key={location.pathname}
                 nodeRef={nodeRef}
-                timeout={400}
+                timeout={200}
                 classNames="fade"
                 unmountOnExit
               >
-                <div className="fade">
+                {/* @ts-ignore */}
+                <div ref={nodeRef} className="fade">
                   <Outlet />
                 </div>
               </CSSTransition>

--- a/src/client/Root.tsx
+++ b/src/client/Root.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, createRef } from 'react';
+import React, { Suspense, createRef, RefObject } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 
 import NavBar from './components/Navbar';
@@ -6,18 +6,53 @@ import NavBar from './components/Navbar';
 import Loader from './components/Loader';
 
 // import React transition group
+import { SwitchTransition, CSSTransition } from 'react-transition-group';
 
 // import wrapper components for routes for React transition group
-
+import HomeWrapper from './components/HomeWrapper';
+import ExploreChaanWrapper from './components/ExploreChaanWrapper';
+import About from './components/About';
+import Login from './components/Login';
+import UserPostsWrapper from './components/UserPostsWrapper';
+import Dashboard from './components/Dashboard';
 
 const Root = () => {
 
+// per info, useRef(null) is the functional component way of creating refs, createRef() was
+// the older class based way of creating refs???
+  const routes = [
+    { path: '/', name: 'Home', element: <HomeWrapper />, nodeRef: createRef() as RefObject<HTMLElement>},
+    { path: '/explore', name: 'Explore', element: <ExploreChaanWrapper />, nodeRef: createRef() as RefObject<HTMLElement>},
+    { path: '/about', name: 'About', element: <About />, nodeRef: createRef() as RefObject<HTMLElement>},
+    { path: '/login', name: 'Login', element: <Login />, nodeRef: createRef() as RefObject<HTMLElement>},
+    { path: '/user', name: 'Dashboard', element: <Dashboard />, nodeRef: createRef() as RefObject<HTMLElement>},
+    { path: '/posts/:user_id', name: 'UserPosts', element: <UserPostsWrapper />, nodeRef: createRef() as RefObject<HTMLElement>},
+  ];
+
+  const location = useLocation();
+
+  const { nodeRef } = routes.find((route) => route.path === location.pathname) ?? {};
+
   return(
-    <div className='main'>
+    <div className='root'>
       <NavBar />
       <main>
         <Suspense fallback={<Loader />} >
-          <Outlet />
+          <div className="react-transition-container">
+            <SwitchTransition>
+              <CSSTransition
+                key={location.pathname}
+                nodeRef={nodeRef}
+                timeout={400}
+                classNames="fade"
+                unmountOnExit
+              >
+                <div className="fade">
+                  <Outlet />
+                </div>
+              </CSSTransition>
+            </SwitchTransition>
+          </div>
         </Suspense>
       </main>
 

--- a/src/client/Root.tsx
+++ b/src/client/Root.tsx
@@ -50,7 +50,9 @@ const Root = () => {
                 classNames="fade"
                 unmountOnExit
               >
-                {/* @ts-ignore */}
+                {/* - nodeRef is casted as RefObject<HTMLElement> at routes array to satisfy original 
+                type issue for nodeRef prop of CSSTransition */}
+                {/* @ts-ignore  */}
                 <div ref={nodeRef} className="fade">
                   <Outlet />
                 </div>

--- a/src/client/components/UserPostsWrapper.tsx
+++ b/src/client/components/UserPostsWrapper.tsx
@@ -6,12 +6,12 @@ import Loader from './Loader';
 
 import { UserPostsProps } from '../../types';
 
-const HomeWrapper = () => {
+const UserPostsWrapper = () => {
 
   const { userPostsData } = useLoaderData() as Record<string, Promise<UserPostsProps[]> | UserPostsProps[]>;
 
-  console.log('inside HomeWrapper: data from useLoaderData / publicPostsLoader', userPostsData);
-  console.log('HomeWrapper component rendered');
+  console.log('inside UserPostsWrapper: data from useLoaderData / publicPostsLoader', userPostsData);
+  console.log('UserPostsWrapper component rendered');
 
   return(
     <Suspense fallback={<Loader />} >
@@ -23,4 +23,4 @@ const HomeWrapper = () => {
   )
 };
 
-export default HomeWrapper;
+export default UserPostsWrapper;

--- a/src/client/loaders/userPostsLoader.ts
+++ b/src/client/loaders/userPostsLoader.ts
@@ -37,6 +37,7 @@ const userPostsLoader = (queryClient: QueryClient) =>
   async (props: { params: Record<string, string>} ) => {
 
     const { params } = props;
+    console.log('inside userPostsLoader, params: ', params, ' , user_id: ', params.user_id, ' ,type: ', typeof params.user_id);
 
     console.log('inside userPostsLoader');
 

--- a/src/client/style/style.css
+++ b/src/client/style/style.css
@@ -60,7 +60,7 @@ body {
 .fade-enter-active {
   /* margin: 0 auto; */
   opacity: 1;
-  transition: opacity 400ms;
+  transition: opacity 200ms;
 }
 
 .fade-exit {

--- a/src/client/style/style.css
+++ b/src/client/style/style.css
@@ -343,11 +343,19 @@ body {
 
   .postsComponent {
     display: flex;
+    flex-direction: column;
+    /* flex-wrap: wrap; */
+    width: 95%;
+    margin: 0 auto;
+
+  }
+
+  .postsComponentInnerContainer {
+    display: flex;
     flex-direction: row;
     flex-wrap: wrap;
     width: 95%;
     margin: 0 auto;
-
   }
 
   .imageContainer {

--- a/src/client/style/style.css
+++ b/src/client/style/style.css
@@ -4,6 +4,9 @@ html {
   height: 100%;
   margin: 0;
   font-family: 'Noto Sans JP', sans-serif;
+  background-image: url("../images/wood_bg_landscape.jpg");
+  background-size: contain;
+  /* background-repeat: repeat-y; */
 }
 
 body {
@@ -18,15 +21,15 @@ body {
   box-sizing: border-box;
 } */
 
-.main {
-  background-image: url("../images/wood_bg_landscape.jpg");
+.root {
+  /* background-image: url("../images/wood_bg_landscape.jpg");
   background-size: contain;
-  background-repeat: repeat-y;
-  height: 100%;
-  width: 100%;
-  display: flex;
+  background-repeat: repeat-y; */
+  height: 100vh;
+  width: 100vw;
+  /* display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: center; */
 }
 
 .routesContainer {
@@ -39,8 +42,14 @@ body {
   /* margin: 0 auto; */
 }
 
+.react-transition-container {
+  position: relative;
+  /* width: 100%; */
+}
+
 .fade {
   position: absolute;
+  width: 100vw;
 }
 
 .fade-enter {
@@ -51,7 +60,7 @@ body {
 .fade-enter-active {
   /* margin: 0 auto; */
   opacity: 1;
-  transition: opacity 300ms;
+  transition: opacity 400ms;
 }
 
 .fade-exit {
@@ -60,7 +69,7 @@ body {
 
 .fade-exit-active {
   opacity: 0;
-  transition: opacity 300ms;
+  transition: opacity 0ms;
 }
 
 .navBar {


### PR DESCRIPTION
Implemented route transitions using react-transition-group. There is still an outstanding issue with fading out the exiting component, so the transition time has been reduced to 0ms. This might be an issue due to React 18 batching of updates as per an issue filed with GitHub. Will need to further investigate. In Root.tsx, issue with type of nodeRef when assigned to ref prop of div element className fade that is parent to <Outlet />, @ts-error applied for now. Also flex wrap applied to postsComponentInner container instead of postsComponent for desktop styling. 