### PR TITLE
Added innerContainer to Posts, applied flex-wrap styling, and streamlined font-sizes

### DIFF
--- a/src/client/components/Posts.tsx
+++ b/src/client/components/Posts.tsx
@@ -6,11 +6,12 @@ import ImagePost from './ImagePost';
 
 const Posts =  (props: { userPostsData: UserPostsProps[] })  => {
   const { userPostsData } = props;
+  const { username } = userPostsData[0];
 
   return(
     <div className="postsComponent">
-      {/* <h1>User Posts</h1> */}
-        {/* <div> */}
+      <h1>{username}</h1>
+        <div className="postsComponentInnerContainer">
           { 
             userPostsData?.map((imagePostMetadata: ImagePostProps, idx: number) => {
             // const { username, user_id, timestamp, url, caption, likes, likesData } = object;
@@ -21,7 +22,7 @@ const Posts =  (props: { userPostsData: UserPostsProps[] })  => {
                     />);
             })
           }
-        {/* </div>  */}
+        </div> 
     </div>
   )
 };

--- a/src/client/style/style.css
+++ b/src/client/style/style.css
@@ -347,6 +347,8 @@ body {
     /* flex-wrap: wrap; */
     width: 95%;
     margin: 0 auto;
+    font-size: 1.3rem;
+
 
   }
 
@@ -379,7 +381,7 @@ body {
     /* width: 95%; */
     /* min-height: 100vh; */
     margin: 0 auto;
-    font-size: 1.5rem; 
+    font-size: 1.3rem; 
   }
   
   .exploreInnerContainer {


### PR DESCRIPTION
In Posts component, added innerContainer class to match Dashboard and Home component, flex-wrap applied to innerContainer class. Also set the font to Home, Dashboard, Posts and Explore to 1.3rem for desktop to streamline the font size. Might need additional streamlining of font sizes and margin spacing of different component views. 